### PR TITLE
Empty Files from Trash bins Older than 7 days + Add CronJob to Clean Up Failed Uploads

### DIFF
--- a/base/manifests/cronjob-nextcloud-failed-upload-cleanup.yaml
+++ b/base/manifests/cronjob-nextcloud-failed-upload-cleanup.yaml
@@ -10,7 +10,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: nextcloud-tmp-cleanup
+  name: nextcloud-failed-upload-cleanup
 spec:
   schedule: "0 * * * *"
   jobTemplate:

--- a/base/manifests/cronjob-nextcloud-tmp-cleanup.yaml
+++ b/base/manifests/cronjob-nextcloud-tmp-cleanup.yaml
@@ -1,0 +1,96 @@
+##
+# Kubernetes deployment manifest for clearing failed uploads older than 7 days
+# every hour.
+#
+# @author Guy Elsmore-Paddock (guy@inveniem.com)
+# @author Brandon McWhirter (brandon.mcwhirter@inveniem.com)
+# @copyright Copyright (c) 2022, Inveniem
+# @license GNU AGPL version 3 or any later version
+#
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nextcloud-tmp-cleanup
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cron-nextcloud
+              image: "inveniem/nextcloud-cron:latest"
+              args:
+                - '-s'
+                - 'bash'
+                - '/cleanup_uploads.sh'
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 128Mi
+                limits:
+                  cpu: 1500m
+                  memory: 512Mi
+              volumeMounts:
+                - name: volume-nextcloud-app
+                  mountPath: /var/www/html
+              env:
+                - name: NEXTCLOUD_FILE_LOCKING_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: environment
+                      key: enableFileLocking
+                - name: NEXTCLOUD_TRUSTED_DOMAINS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: environment
+                      key: trustedDomains
+                - name: NEXTCLOUD_ADMIN_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-admin-creds"
+                      key: username
+                - name: NEXTCLOUD_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-admin-creds"
+                      key: password
+                - name: MYSQL_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-mysql-creds"
+                      key: hostname
+                - name: MYSQL_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-mysql-creds"
+                      key: port
+                - name: MYSQL_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-mysql-creds"
+                      key: database
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-mysql-creds"
+                      key: username
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-mysql-creds"
+                      key: password
+                - name: REDIS_HOST
+                  value: "internal-redis"
+                - name: REDIS_PORT
+                  value: "6379"
+                - name: REDIS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nextcloud-redis-creds"
+                      key: password
+          volumes:
+            # Ephemeral volume that contains the loaded Nextcloud software
+            - name: volume-nextcloud-app
+              emptyDir: {}

--- a/docker/nextcloud-common/config/trashbin.config.php
+++ b/docker/nextcloud-common/config/trashbin.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array(
+  "trashbin_retention_obligation" => "auto, 14",
+);

--- a/docker/nextcloud-cron/Dockerfile
+++ b/docker/nextcloud-cron/Dockerfile
@@ -19,6 +19,8 @@ RUN rm -f /usr/src/nextcloud/config/redis.config.php
 COPY nextcloud-cron/entrypoint.sh /
 COPY nextcloud-common/config/* /usr/src/nextcloud/config/
 
+COPY nextcloud-cron/cleanup_uploads.sh /
+
 # Ensure custom apps are available during cron runs.
 # We supply all custom apps via Docker image; app store is disabled
 COPY nextcloud-common/custom_apps/. /usr/src/nextcloud/custom_apps/

--- a/docker/nextcloud-cron/cleanup_uploads.sh
+++ b/docker/nextcloud-cron/cleanup_uploads.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+##
+# Nextcloud Docker script to clean up failed uploads for Nextcloud cron runs.
+#
+# @author Guy Elsmore-Paddock (guy@inveniem.com)
+# @author Brandon McWhirter (brandon.mcwhirter@inveniem.com)
+# @copyright Copyright (c) 2022, Inveniem
+# @license GNU AGPL version 3 or any later version
+#
+
+set -eu
+
+cd /var/www/html/
+
+find . -wholename "*uploads/web-file-upload*" -type d ! -mtime 7 -exec rm -rvf "{}" ";"


### PR DESCRIPTION
Added trashbin config to empty user trashbins regularly. Also added script to nextcloud-cron to clear failed uploads after 7 days. Created cronjob to run script added to nextcloud-cron.