### PR TITLE
Fix Rigger launch-shell to Grab the Correct Pod by Label Instead

### DIFF
--- a/bin/rigger
+++ b/bin/rigger
@@ -53,6 +53,7 @@ docker_image_names=(
 )
 
 nextcloud_deployment_name="nextcloud"
+nextcloud_backend_pod_label="backend-nextcloud"
 
 environment_config_path="manifests/config-environment.yaml"
 
@@ -761,10 +762,11 @@ sub_scale() {
 #
 sub_launch_shell() {
   declare -g nextcloud_deployment_name
+  declare -g nextcloud_backend_pod_label
   declare -g error_bad_environment
 
   pod_name=$(
-    kubectl get pods -n "${namespace}" -o name |
+    kubectl get pods -n "${namespace}" --selector="app=${nextcloud_backend_pod_label}" -o name |
       grep -m1 "${nextcloud_deployment_name}" || echo ""
   )
 


### PR DESCRIPTION
When launching a shell from `rigger`, it assumes that the backend pods will be the first pods in the list. This is not always the case. This change will select the backend pods by label instead which will ensure the correct pods are chosen every time.