### PR TITLE
Add Reference to Upload Cleanup `CronJob` to base `kustomization.yaml`

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   - manifests/app-clamav.yaml
   - manifests/app-redis.yaml
   - manifests/cronjob-nextcloud-cron.yaml
+  - manifests/cronjob-nextcloud-failed-upload-cleanup.yaml
   - manifests/cronjob-nextcloud-file-scan.yaml
   - manifests/pod-disruption-budgets.yaml


### PR DESCRIPTION
Added failed upload cleanup cronjob to the `kustomization.yaml` config file so it will be deployed with the other cronjobs.