### PR TITLE
[ITSA-583] [ITSA-1309] Apply Multiple Fixes to CronJobs + Prevent Overlap

### DIFF
--- a/base/manifests/cronjob-nextcloud-cron.yaml
+++ b/base/manifests/cronjob-nextcloud-cron.yaml
@@ -11,6 +11,7 @@ metadata:
   name: nextcloud-cron
 spec:
   schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:

--- a/base/manifests/cronjob-nextcloud-failed-upload-cleanup.yaml
+++ b/base/manifests/cronjob-nextcloud-failed-upload-cleanup.yaml
@@ -24,7 +24,7 @@ spec:
               image: "inveniem/nextcloud-cron:latest"
               args:
                 - '-s'
-                - 'bash'
+                - '/bin/sh'
                 - '/cleanup_uploads.sh'
               resources:
                 requests:

--- a/base/manifests/cronjob-nextcloud-failed-upload-cleanup.yaml
+++ b/base/manifests/cronjob-nextcloud-failed-upload-cleanup.yaml
@@ -13,6 +13,7 @@ metadata:
   name: nextcloud-failed-upload-cleanup
 spec:
   schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:

--- a/base/manifests/cronjob-nextcloud-file-scan.yaml
+++ b/base/manifests/cronjob-nextcloud-file-scan.yaml
@@ -11,6 +11,7 @@ metadata:
   name: nextcloud-file-scan
 spec:
   schedule: "0 12,20 * * *"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:

--- a/docker/nextcloud-cron/cleanup_uploads.sh
+++ b/docker/nextcloud-cron/cleanup_uploads.sh
@@ -11,6 +11,8 @@
 
 set -eu
 
-cd /var/www/html/
-
-find . -wholename "*uploads/web-file-upload*" -type d ! -mtime 7 -exec rm -rvf "{}" ";"
+find /var/www/html/ \
+  -wholename "*uploads/web-file-upload*" \
+  -type d \
+  ! -mtime 7 \
+  -exec rm -rvf "{}" ";"


### PR DESCRIPTION
This ensures that each cronjob does not start until its previous run has finished.