### PR TITLE
[ITSA-1478] Prefer Scheduling Burstable Workloads on Burstable Nodes

### DIFF
--- a/base/manifests/app-clamav.yaml
+++ b/base/manifests/app-clamav.yaml
@@ -27,6 +27,28 @@ spec:
         app: backend-clamav
         role: backend
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            # Prefer to be scheduled on a burstable node.
+            #
+            # NOTE: "inveniem.com/workload-type" is a *label* that has the same
+            # name and value as the *taint* on the same nodes. Kubernetes
+            # doesn't have a way to use the taint for affinity, so we duplicate
+            # it as a label.
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: inveniem.com/workload-type
+                    operator: In
+                    values:
+                      - burstable
+      tolerations:
+        # Allow scheduling this job on burstable nodes.
+        - key: inveniem.com/workload-type
+          operator: Equal
+          value: burstable
+          effect: NoSchedule
       containers:
         - name: backend-clamav
           image: "mkodockx/docker-clamav:latest"

--- a/base/manifests/cronjob-nextcloud-cron.yaml
+++ b/base/manifests/cronjob-nextcloud-cron.yaml
@@ -17,6 +17,28 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              # Prefer to be scheduled on a burstable node.
+              #
+              # NOTE: "inveniem.com/workload-type" is a *label* that has the same
+              # name and value as the *taint* on the same nodes. Kubernetes
+              # doesn't have a way to use the taint for affinity, so we duplicate
+              # it as a label.
+              - weight: 100
+                preference:
+                  matchExpressions:
+                    - key: inveniem.com/workload-type
+                      operator: In
+                      values:
+                        - burstable
+          tolerations:
+            # Allow scheduling this job on burstable nodes.
+            - key: inveniem.com/workload-type
+              operator: Equal
+              value: burstable
+              effect: NoSchedule
           containers:
             - name: cron-nextcloud
               image: "inveniem/nextcloud-cron:latest"

--- a/components/http-apache/manifests/app-nextcloud.apache.yaml
+++ b/components/http-apache/manifests/app-nextcloud.apache.yaml
@@ -22,6 +22,21 @@ spec:
         role: backend
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            # Prefer to be scheduled on a burstable node.
+            #
+            # NOTE: "inveniem.com/workload-type" is a *label* that has the same
+            # name and value as the *taint* on the same nodes. Kubernetes
+            # doesn't have a way to use the taint for affinity, so we duplicate
+            # it as a label.
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: inveniem.com/workload-type
+                    operator: In
+                    values:
+                      - burstable
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             # Prevent multiple replicas from being on the same node.

--- a/components/http-nginx-fpm/manifests/app-nextcloud.nginx-fpm.yaml
+++ b/components/http-nginx-fpm/manifests/app-nextcloud.nginx-fpm.yaml
@@ -23,6 +23,21 @@ spec:
         role: backend
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            # Prefer to be scheduled on a burstable node.
+            #
+            # NOTE: "inveniem.com/workload-type" is a *label* that has the same
+            # name and value as the *taint* on the same nodes. Kubernetes
+            # doesn't have a way to use the taint for affinity, so we duplicate
+            # it as a label.
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: inveniem.com/workload-type
+                    operator: In
+                    values:
+                      - burstable
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             # Prevent multiple replicas from being on the same node.


### PR DESCRIPTION
This expands the pods that can be scheduled on burstable nodes to include ClamAV and Nextcloud's standard Cron task. The Apache and FPM images already support being burstable.

Several of these pods already had tolerations to be scheduled on burstable nodes, but Kubernetes would only do that as a last resort. This conveys to the scheduler that these pods actually prefer that.

Unfortunately, there is not a way to use a taint as a matching criterion, so we had to duplicate the taint as a label on the node pool. This was added with a command like the following:

```
az aks nodepool update \
  --resource-group RESOURCE-GROUP \
  --cluster-name CLUSTER-NAME \
  --name NODE-POOL-NAME \
  --labels inveniem.com/workload-type=burstable
```