### PR TITLE
Add Support for Maintenance Pages/Messages during Scheduled Downtime

### DIFF
--- a/components/maintenance_page/kustomization.yaml
+++ b/components/maintenance_page/kustomization.yaml
@@ -1,0 +1,51 @@
+##
+# Kustomization component to serve up a maintenance page instead of Nextcloud.
+#
+# The configuration for the maintenance page comes from a
+# config-environment.yaml file provided by the overlay for the environment. This
+# functionality has been provided as a component so that it only needs to be
+# referenced by an overlay when traffic served by that overlay should be routed
+# away from Nextcloud, such as during scheduled downtime. The component
+# accomplishes this by rewriting the ingress routes for Nextcloud to route
+# traffic to the maintenance page service instead of Nextcloud itself.
+#
+# To enable the maintenance page for the environment of an overlay:
+# 1. Customize the appropriate settings in the config-environment.yaml of the
+#    overlay.
+# 2. Uncomment the reference to this component in the `kustomization.yaml` file.
+# 3. Re-deploy the overlay.
+#
+# To disable the maintenance page for the environment of an overlay:
+# 1. Comment out the reference to this component in the `kustomization.yaml`
+#    file.
+# 2. Re-deploy the overlay.
+#
+# @author Guy Elsmore-Paddock (guy@inveniem.com)
+# @copyright Copyright (c) 2023-2024, Inveniem
+# @license GNU AGPL version 3 or any later version
+#
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - manifests/app-maintenance_page.yaml
+
+patches:
+  - target:
+      kind: Ingress
+      name: "frontend-nextcloud-ingress"
+      labelSelector: "owning-app=nextcloud"
+    patch: |
+      [
+        {
+          "op": "replace",
+          "path": "/spec/rules/0/http/paths/0/backend/service/name",
+          "value": "internal-maintenance-page"
+        },
+        {
+          "op": "replace",
+          "path": "/spec/rules/0/http/paths/0/backend/service/port/number",
+          "value": 8080
+        }
+      ]
+      

--- a/components/maintenance_page/manifests/app-maintenance_page.yaml
+++ b/components/maintenance_page/manifests/app-maintenance_page.yaml
@@ -1,0 +1,105 @@
+##
+# Kubernetes deployment manifest for running a simple maintenance page during
+# scheduled/planned downtime.
+#
+# The messages displayed are configured in the config-environment.yaml file
+# provided by the overlay for the environment.
+#
+# @author Guy Elsmore-Paddock (guy@inveniem.com)
+# @copyright Copyright (c) 2023-2024, Inveniem
+# @license GNU AGPL version 3 or any later version
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maintenance-page
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: frontend-maintenance-page
+      role: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend-maintenance-page
+        role: frontend
+    spec:
+      tolerations:
+        # Allow scheduling this job on burstable nodes.
+        - key: inveniem.com/workload-type
+          operator: Equal
+          value: burstable
+          effect: NoSchedule
+      containers:
+        - name: frontend-maintenance-page
+          image: "wickerlabs/maintenance:latest"
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          env:
+            - name: TITLE
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceTitle
+            - name: HEADLINE
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceHeadline
+            - name: MESSAGE
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceMessage
+            - name: CONTACT_LINK
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceContactLink
+            - name: MAIL_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceMailAddress
+            - name: TEAM_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceTeamName
+            - name: LINK_COLOR
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceLinkColor
+            - name: THEME
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceTheme
+            - name: RESPONSE_CODE
+              valueFrom:
+                configMapKeyRef:
+                  name: environment
+                  key: maintenanceResponseCode
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: internal-maintenance-page
+  labels:
+    role: internal-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+  selector:
+    app: frontend-maintenance-page

--- a/overlays/00-sample/kustomization.yaml
+++ b/overlays/00-sample/kustomization.yaml
@@ -32,6 +32,16 @@ components:
   - ../../components/cert-manager-lets-encrypt
   - ../../components/ingress-dns
 
+# Uncomment the line after this comment and re-deploy this overlay to serve up a
+# maintenance page for end users, rather than the normal Nextcloud application.
+# To reverse this and restore access, comment out the component and re-deploy
+# the overlay.
+#
+# This does not prevent deployment of Nextcloud, but does block access to it by
+# end users. No other components have to be commented out for this to work.
+#
+# - ../../components/maintenance_page
+
 generators:
   - decrypt-secrets.nextcloud.yaml
 #### Uncomment this if using the "sftp-server" component:

--- a/overlays/00-sample/manifests/config-environment.yaml
+++ b/overlays/00-sample/manifests/config-environment.yaml
@@ -29,3 +29,18 @@ data:
         "mynextcloudstorageaccount": "nextcloud-azure-files-creds"
       }
     }
+
+  # Settings when in maintenance mode (toggle this mode on by including the
+  # maintenance_page component in your overlay).
+  #
+  # See this page for a description of the settings:
+  # https://github.com/wickerlabs/maintenance
+  maintenanceTitle: "Site Maintenance"
+  maintenanceHeadline: "We'll be back soon!"
+  maintenanceMessage: "Sorry for the inconvenience but we're performing some maintenance at the moment. If you need to you can always {{contact}}, otherwise we'll be back online shortly!"
+  maintenanceContactLink: "contact us"
+  maintenanceMailAddress: "mail@example.com"
+  maintenanceTeamName: "The Team"
+  maintenanceLinkColor: "#dc8100"
+  maintenanceTheme: "Light"
+  maintenanceResponseCode: "503"


### PR DESCRIPTION
This adds a new maintenance page component to the project that can be enabled in an overlay to switch over at ingress level to display a message to end users during scheduled maintenance.